### PR TITLE
report invalid keys in enum->fns ex-data

### DIFF
--- a/src/clj/qbits/commons/enum.clj
+++ b/src/clj/qbits/commons/enum.clj
@@ -74,4 +74,5 @@
                     enum-map)
           (throw (ex-info ~(format "Invalid Enum key - possible keys are -> %s"
                                    (str/join ", " (map key enum-map)))
-                          {:type  ::invalid-enum-value})))))))
+                          {:type  ::invalid-enum-value
+                           :key x#})))))))

--- a/test/qbits/commons/enum_test.clj
+++ b/test/qbits/commons/enum_test.clj
@@ -1,0 +1,25 @@
+(ns qbits.commons.enum-test
+  (:require
+   [clojure.test :as t :refer [deftest testing is]]
+   [qbits.commons.enum :as sut])
+  (:import
+   [java.math RoundingMode]))
+
+(deftest enum->fn-test
+  (testing "rounding-mode retrieval"
+    (let [efn (sut/enum->fn RoundingMode)
+          v (efn :up)]
+      (is (instance? RoundingMode v))
+      (is (= "UP" (str v)))))
+
+  (testing "invalid key is reported in ex-data"
+    (let [efn (sut/enum->fn RoundingMode)
+          v (try
+              (efn :foo)
+              (catch Exception err err))
+          {exd-t :type
+           exd-k :key
+           :as exd} (ex-data v)]
+      (is (some? exd))
+      (is (= ::sut/invalid-enum-value exd-t))
+      (is (= :foo exd-k)))))


### PR DESCRIPTION
an `enum->fn` throws an exception when an invalid key is used, but doesn't report the key used in the `ex-data`

this PR includes the invalid key in the `ex-data`