### PR TITLE
Report invalid enum->fn key in exception message

### DIFF
--- a/src/clj/qbits/commons/enum.clj
+++ b/src/clj/qbits/commons/enum.clj
@@ -72,7 +72,9 @@
                               (str enum-symbol "/")
                               symbol)])
                     enum-map)
-          (throw (ex-info ~(format "Invalid Enum key - possible keys are -> %s"
-                                   (str/join ", " (map key enum-map)))
-                          {:type  ::invalid-enum-value
-                           :key x#})))))))
+          (throw (ex-info
+                  (format "Invalid Enum key - %s - possible keys are -> %s"
+                          x#
+                          ~(str/join ", " (map key enum-map)))
+                  {:type  ::invalid-enum-value
+                   :key x#})))))))

--- a/test/qbits/commons/enum_test.clj
+++ b/test/qbits/commons/enum_test.clj
@@ -1,7 +1,8 @@
 (ns qbits.commons.enum-test
   (:require
    [clojure.test :as t :refer [deftest testing is]]
-   [qbits.commons.enum :as sut])
+   [qbits.commons.enum :as sut]
+   [clojure.string :as str])
   (:import
    [java.math RoundingMode]))
 
@@ -12,14 +13,16 @@
       (is (instance? RoundingMode v))
       (is (= "UP" (str v)))))
 
-  (testing "invalid key is reported in ex-data"
+  (testing "invalid key is reported in ex-data and exception message"
     (let [efn (sut/enum->fn RoundingMode)
           v (try
               (efn :foo)
               (catch Exception err err))
           {exd-t :type
            exd-k :key
-           :as exd} (ex-data v)]
+           :as exd} (ex-data v)
+          ex-msg (when (instance? Exception v) (.getMessage ^Exception v))]
       (is (some? exd))
       (is (= ::sut/invalid-enum-value exd-t))
-      (is (= :foo exd-k)))))
+      (is (= :foo exd-k))
+      (is (str/starts-with? ex-msg "Invalid Enum key - :foo" )))))


### PR DESCRIPTION
it turns out that sometimes an invalid `enum->fn` key gets reported by a command-line tool (e.g. a `lein` command) without the stacktrace, so the `ex-data` is not visible - only the exception message is shown

this PR adds the invalid key to the exception message too